### PR TITLE
Remove hardcoded segment index in `TupleDataCollection::FetchChunk`

### DIFF
--- a/src/common/types/row/tuple_data_collection.cpp
+++ b/src/common/types/row/tuple_data_collection.cpp
@@ -566,11 +566,16 @@ void TupleDataCollection::InitializeScan(TupleDataParallelScanState &state, vect
 	InitializeScan(state.scan_state, std::move(column_ids), properties);
 }
 
-idx_t TupleDataCollection::FetchChunk(TupleDataScanState &state, const idx_t segment_idx, const idx_t chunk_idx,
-                                      const bool init_heap) {
-	auto &segment = *segments[segment_idx];
-	allocator->InitializeChunkState(segment, state.pin_state, state.chunk_state, chunk_idx, init_heap);
-	return segment.chunks[chunk_idx].count;
+idx_t TupleDataCollection::FetchChunk(TupleDataScanState &state, idx_t chunk_idx, bool init_heap) {
+	for (idx_t segment_idx = 0; segment_idx < segments.size(); segment_idx++) {
+		auto &segment = *segments[segment_idx];
+		if (chunk_idx < segment.ChunkCount()) {
+			allocator->InitializeChunkState(segment, state.pin_state, state.chunk_state, chunk_idx, init_heap);
+			return segment.chunks[chunk_idx].count;
+		}
+		chunk_idx -= segment.ChunkCount();
+	}
+	throw InternalException("Chunk index out of in TupleDataCollection::FetchChunk");
 }
 
 bool TupleDataCollection::Scan(TupleDataScanState &state, DataChunk &result) {

--- a/src/include/duckdb/common/types/row/block_iterator.hpp
+++ b/src/include/duckdb/common/types/row/block_iterator.hpp
@@ -183,15 +183,14 @@ private:
 			key_scan_state.pin_state.row_handles.acquire_handles(pins);
 			key_scan_state.pin_state.heap_handles.acquire_handles(pins);
 		}
-		key_data.FetchChunk(key_scan_state, 0, chunk_idx, false);
+		key_data.FetchChunk(key_scan_state, chunk_idx, false);
 		if (pin_payload && payload_data) {
 			if (keep_pinned) {
 				payload_scan_state.pin_state.row_handles.acquire_handles(pins);
 				payload_scan_state.pin_state.heap_handles.acquire_handles(pins);
 			}
-			const auto chunk_count = payload_data->FetchChunk(payload_scan_state, 0, chunk_idx, false);
+			const auto chunk_count = payload_data->FetchChunk(payload_scan_state, chunk_idx, false);
 			const auto sort_keys = reinterpret_cast<T **const>(key_ptrs);
-			payload_data->FetchChunk(payload_scan_state, 0, chunk_idx, false);
 			const auto payload_ptrs = FlatVector::GetData<data_ptr_t>(payload_scan_state.chunk_state.row_locations);
 			for (idx_t i = 0; i < chunk_count; i++) {
 				sort_keys[i]->SetPayload(payload_ptrs[i]);

--- a/src/include/duckdb/common/types/row/tuple_data_collection.hpp
+++ b/src/include/duckdb/common/types/row/tuple_data_collection.hpp
@@ -186,8 +186,8 @@ public:
 	//! Initialize a parallel scan over the tuple data collection over a subset of the columns
 	void InitializeScan(TupleDataParallelScanState &gstate, vector<column_t> column_ids,
 	                    TupleDataPinProperties properties = TupleDataPinProperties::UNPIN_AFTER_DONE) const;
-	//! Grab the chunk state for the given segment and chunk index, returns the count of the chunk
-	idx_t FetchChunk(TupleDataScanState &state, idx_t segment_idx, idx_t chunk_idx, bool init_heap);
+	//! Grab the chunk state for the given chunk index, returns the count of the chunk
+	idx_t FetchChunk(TupleDataScanState &state, idx_t chunk_idx, bool init_heap);
 	//! Scans a DataChunk from the TupleDataCollection
 	bool Scan(TupleDataScanState &state, DataChunk &result);
 	//! Scans a DataChunk from the TupleDataCollection


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5823

Is properly computed from the segments now.